### PR TITLE
Bump the priority of the bundle so other payment methods can go before this one

### DIFF
--- a/src/Resources/config/oro/bundles.yml
+++ b/src/Resources/config/oro/bundles.yml
@@ -1,2 +1,2 @@
 bundles:
-    - { name: Payplug\Bundle\PaymentBundle\PayplugPaymentBundle, priority: 5 }
+    - { name: Payplug\Bundle\PaymentBundle\PayplugPaymentBundle, priority: 50 }


### PR DESCRIPTION
#### PR reason
The current priority (5) does not allow to put other bundles (with other payment methods) before this one, so this one always appears first in the UI. This PR will allow the change of the payment methods view order.  